### PR TITLE
[cmactions] Fix ArrayIndexOutOfBoundsException in ProximitySilencer

### DIFF
--- a/cmactions/src/com/cyanogenmod/settings/device/ProximitySilencer.java
+++ b/cmactions/src/com/cyanogenmod/settings/device/ProximitySilencer.java
@@ -77,8 +77,7 @@ public class ProximitySilencer extends PhoneStateListener implements SensorEvent
         }
 
         if (!isNear && mIsRinging) {
-            Log.d(TAG, "event: [" + event.values.length + "]: " + event.values[0] + ", " +
-                event.values[1] + ", " + event.values[2] + " covered " + Boolean.toString(mCoveredRinging));
+            Log.d(TAG, "event: [" + event.values.length + "]: " + event.values[0] + Boolean.toString(mCoveredRinging));
             if (mCoveredRinging) {
                 Log.d(TAG, "Silencing ringer");
                 mTelecomManager.silenceRinger();


### PR DESCRIPTION
SensorEvent Sensor.TYPE_PROXIMITY only provides 1 value, not 3.